### PR TITLE
Fix const value root font size loading

### DIFF
--- a/src/AngleSharp.Css/FeatureValidators/DeviceWidthFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/DeviceWidthFeatureValidator.cs
@@ -1,3 +1,5 @@
+using AngleSharp.Css.Values;
+
 namespace AngleSharp.Css.FeatureValidators
 {
     using AngleSharp.Css.Converters;
@@ -11,7 +13,8 @@ namespace AngleSharp.Css.FeatureValidators
         {
             var length = LengthConverter.Convert(feature.Value);
 
-            if (length != null)
+            // Don't validate units that do not yet support conversion to PX from a renderDevice.
+            if (length != null && length is not Length { Type: Length.Unit.Em or Length.Unit.Ex })
             {
                 var desired = length.AsPx(renderDevice, RenderMode.Horizontal);
                 var available = (Double)renderDevice.DeviceWidth;

--- a/src/AngleSharp.Css/FeatureValidators/WidthFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/WidthFeatureValidator.cs
@@ -1,3 +1,5 @@
+using AngleSharp.Css.Values;
+
 namespace AngleSharp.Css.FeatureValidators
 {
     using AngleSharp.Css.Converters;
@@ -11,7 +13,8 @@ namespace AngleSharp.Css.FeatureValidators
         {
             var length = LengthConverter.Convert(feature.Value);
 
-            if (length != null)
+            // Don't validate units that do not yet support conversion to PX from a renderDevice.
+            if (length != null && length is not Length { Type: Length.Unit.Em or Length.Unit.Ex })
             {
                 var desired = length.AsPx(renderDevice, RenderMode.Horizontal);
                 var available = (Double)renderDevice.ViewPortWidth;

--- a/src/AngleSharp.Css/RenderTree/RenderTreeBuilder.cs
+++ b/src/AngleSharp.Css/RenderTree/RenderTreeBuilder.cs
@@ -32,7 +32,13 @@ namespace AngleSharp.Css.RenderTree
             var stylesheets = _defaultSheets.Concat(currentSheets).ToList();
             var collection = new StyleCollection(stylesheets, _device);
             var rootStyle = collection.ComputeCascadedStyle(document.DocumentElement);
-            var rootFontSize = ((Length?) rootStyle.GetProperty(PropertyNames.FontSize)?.RawValue)?.Value ?? 16;
+            var rootFontValue = rootStyle.GetProperty(PropertyNames.FontSize)?.RawValue;
+            var rootFontSize = rootFontValue switch
+            {
+                Length length => length.Value,
+                Constant<Length> constant => constant.Value.Value,
+                _ => 16
+            };
             return RenderElement(rootFontSize, document.DocumentElement, collection);
         }
 

--- a/src/AngleSharp.Css/Values/Primitives/Length.cs
+++ b/src/AngleSharp.Css/Values/Primitives/Length.cs
@@ -309,7 +309,7 @@ namespace AngleSharp.Css.Values
                     CheckForValidRenderDimensions(renderDimensions, RenderMode.Vertical);
                     return _value * 0.01 * Math.Min(renderDimensions.RenderHeight, renderDimensions.RenderWidth);
                 default:
-                    throw new InvalidOperationException("Unsupported unit cannot be converted.");
+                    throw new InvalidOperationException($"Unsupported unit '{_unit}' cannot be converted.");
             }
         }
 
@@ -361,7 +361,7 @@ namespace AngleSharp.Css.Values
                     CheckForValidRenderDimensions(renderDimensions, RenderMode.Horizontal);
                     return value / ( 0.01 * Math.Min(renderDimensions.RenderHeight, renderDimensions.RenderWidth));
                 default:
-                    throw new InvalidOperationException("Unsupported unit cannot be converted.");
+                    throw new InvalidOperationException($"Unsupported unit '{unit}' cannot be converted.");
             }
         }
 


### PR DESCRIPTION
Fixes these errors

```
System.InvalidCastException: Unable to cast object of type 'AngleSharp.Css.Values.Constant`1[AngleSharp.Css.Values.Length]' to type 'System.Nullable`1[AngleSharp.Css.Values.Length]'.
```

Also fixes ICssMediaRule errors occurring when attempting to convert to pixels.

[CON-1021](https://faithlife.atlassian.net/browse/CON-1021)

[CON-1021]: https://faithlife.atlassian.net/browse/CON-1021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ